### PR TITLE
Fix syntax error when importing sharrock.client

### DIFF
--- a/sharrock/client.py
+++ b/sharrock/client.py
@@ -91,7 +91,7 @@ class ParamValidator(object):
             bool(value)
     
     def wildcard_check(self,value):
-        # no-op
+        pass
     
     def check(self,params):
         """


### PR DESCRIPTION
This is not valid Python syntax.